### PR TITLE
Actions from meeting of 8 May 2024.

### DIFF
--- a/20240508.md
+++ b/20240508.md
@@ -33,13 +33,36 @@
   - Identify the most promising load/store vector instruction to optimize.
   - Prepare routine/nightly runs of benchmarks.
 
+## Current priorties
+
+Our current set of agreed priorities are taken from the Statement of Work.
+This has the following priorities, which trade off functionality targeted versus architectures supported.
+
+- vector load/store ops for x86_64 AVX
+- vector load/store ops for AArch64/Neon
+- vector integer ALU ops for x86_64 AVX
+- vector load/store ops for Intel AVX10
+
+For each of these there will be an analysis phase and an optimization phase, leading to the following set of work packages.
+- WP0: Infrastructure
+- WP1: Analysis of vector load/store ops on x86_64 AVX
+- WP2: Optimization of vector load/store ops on x86_64 AVX
+- WP3: Analysis of vector load/store ops on AArch64/Neon
+- WP4: Optimization of vector load/store ops on AArch64/Neon
+- WP5: Analysis of integer ALU ops on x86_64 AVX
+- WP6: Optimization of integer ALU ops on x86_64 AVX
+- WP7: Analysis of vector load/store ops on Intel AVX10
+- WP8: Optimization of vector load/store ops on Intel AVX10
+
+These priorities can be revised by agreement with RISE during the project.
+
 # Detailed description of work
 
 ## WP1
 
 ### SPEC CPU 2017 base line results:
 
-We have run all 20 SPEC CPU 2017 speed tests, 10 integer, 10 floating point, under QEMU. 
+We have run all 20 SPEC CPU 2017 speed tests, 10 integer, 10 floating point, under QEMU.
 We have run the tests both with, and without RISC-V Vector (RVV) enabled.
 See the full results by following the link in the [statistics secion](#SPEC-CPU-2017-performance) below.
 
@@ -96,7 +119,7 @@ We make the following observations:
 We would like to use a subset of the quicker SPEC CPU tests to allow us to check QEMU performance nightly. For this we would like a mix of integer and FP tests, all of which have significantly longer execution times when vectorized. This is slightly problematic, since the only floating point tests where vectorized execution is significantly longer both take over 3 days to complete when vectorized (638.imagick_s and 628.pop2_s). We therefore propose using the following strategy.
 
 - Initially use 619.lbm_s (fp), 620.omnetpp_s (int) and 623.xalancbmk_s (int) as our nightly tests, which we anticipate will complete in around 8-12 hours.
-- Repeat our baseline run using the SPEC CPU test datasets, rather than the ref datasets. These are smaller and should lead to shorter runs. This should give us a richer set of alternatives for nightly testing. 
+- Repeat our baseline run using the SPEC CPU test datasets, rather than the ref datasets. These are smaller and should lead to shorter runs. This should give us a richer set of alternatives for nightly testing.
 
 
 ### Analysis of RVV to TCG to x86:
@@ -138,28 +161,6 @@ This is just a small example focused on vle32.v but we can compare directly the 
 the corresponding TCG basic blocks and the native stranslation of such basic blocks.
 This is going to be extremely useful in our optimization work.
 
-## Current priorties
-
-The Statement of Work proposes the following priorities, which trade off functionality targeted versus architectures supported.
-
-- vector load/store ops for x86_64 AVX
-- vector load/store ops for AArch64/Neon
-- vector integer ALU ops for x86_64 AVX
-- vector load/store ops for Intel AVX10
-
-For each of these there will be an analysis phase and an optimization phase, leading to the following set of work packages.
-- WP0: Infrastructure
-- WP1: Analysis of vector load/store ops on x86_64 AVX
-- WP2: Optimization of vector load/store ops on x86_64 AVX
-- WP3: Analysis of vector load/store ops on AArch64/Neon
-- WP4: Optimization of vector load/store ops on AArch64/Neon
-- WP5: Analysis of integer ALU ops on x86_64 AVX
-- WP6: Optimization of integer ALU ops on x86_64 AVX
-- WP7: Analysis of vector load/store ops on Intel AVX10
-- WP8: Optimization of vector load/store ops on Intel AVX10
-
-These priorities can be revised by agreement with RISE during the project.
-
 # Statistics
 
 ## Memory/string operations
@@ -177,10 +178,10 @@ E.g.:
         {
           size_t num_millions = atoi (argv[1]);
           size_t num_loops = num_millions * 1000000;
-        
+
           for (size_t i = 0; i < num_loops; i++)
             __asm__ ("vadd.vx\t v0, v0, %0" : : "r"(i) : "v0");
-        
+
           return 0;
         }
 
@@ -199,7 +200,28 @@ You can find the baseline execution time and instruction count of the SPEC CPU 2
 
 # Actions
 
-## 1st May
+2024-05-08
+
+- Jeremy to characterise QEMU floating point performance and file it as a performance regression issue in QEMU GitLab.
+- Jeremy to set up "smoke test" SPEC CPU 2017 run using the integer and floating point `specrand` programs (should run in minutes).
+- Daniel to provide git sendmail macro for QEMU patches
+
+  - COMPLETE.
+
+```
+send-email --suppress-cc=sob --to qemu-devel@nongnu.org \
+    --cc qemu-riscv@nongnu.org --cc <list of maintainers>
+```
+
+- Daniel to provide Paolo with list of maintainer email addresses
+
+  - COMPLETE.
+
+- Daniel to advise on Paolo of patch checking script.
+
+  - COMPLETE. Use `./script/checkpatch.pl`
+
+2024-05-01
 
 - Paolo to review the generic [issue](https://gitlab.com/qemu-project/qemu/-/issues/2137) from Palmer Dabbelt to identify ideas for optimization and benchmarks to reuse.
   - WIP: we are working on running the reproducers to see the TCG ops generated by QEMU.


### PR DESCRIPTION
Also take the opportunity to move the "Priorities" section earlier in the report, use standard ISO date format, and delete some trailing whitespace.

	* 20240508.md: Add actions, small restructuring and cleanup.